### PR TITLE
Brigid, non-Fodlan names

### DIFF
--- a/common/culture/cultures/fodlan_culture.txt
+++ b/common/culture/cultures/fodlan_culture.txt
@@ -643,18 +643,172 @@
 		}
 	}	
 	
-	kupalan = {
+kupalan = {
 		graphical_cultures = {
 			western_coa_gfx
 		}
 
 		color = hsv { 156 155 93 }
 
-		cadet_dynasty_names = {
+		cadet_dynasty_names = { #Romanian, their blood ritual feels very Dracula-esque
+			"dynn_Litovoi"
+			"dynn_SelimoviC_"
+			"dynn_CsA_ky"
+			"dynn_DezsO_fi"
+			"dynn_Guthi-OrszA_gh"
+			"dynn_MarczaltO_vi"
+			"dynn_Petenye"
+			"dynn_Tibai"
+			"dynn_ZA_ch"
+			"dynn_Szapolyai"
+			"dynn_VA_rdai"
+			"dynn_ProdaniC_"
+			"dynn_Odescalchi"
+			"dynn_Costin"
+			"dynn_BA_dA_rA_u"
+			"dynn_BA_lA_ceanu"
+			"dynn_Bosie"
+			"dynn_BrA_iloi"
+			"dynn_BuS_ilA_"
+			"dynn_Calerghi"
+			"dynn_Callimachi"
+			"dynn_Cantemir"
+			"dynn_Carianopol"
+			"dynn_Crihan"
+			"dynn_Carionfil"
+			"dynn_Cristescu"
+			"dynn_Casassovici"
+			"dynn_Cesianu"
+			"dynn_ChinteS_ti"
+			"dynn_Chirescu"
+			"dynn_CoteS_ti"
+			"dynn_CraioveS_tilor"
+			"dynn_CrA_snaru"
+			"dynn_Dinastia"
+			"dynn_DA_neS_tilor"
+			"dynn_Diamandy"
+			"dynn_DrA_culeS_tilor"
+			"dynn_DrugA_"
+			"dynn_Eliescu"
+			"dynn_Emandi"
+			"dynn_Filipescu"
+			"dynn_Florescu"
+			"dynn_FundA_T_eni"
+			"dynn_Giosani"
+			"dynn_Golescu"
+			"dynn_GrA_diS_teanu"
+			"dynn_Greceanu"
+			"dynn_Hagi"
+			"dynn_HA_jdA_u"
+			"dynn_Jianu"
+			"dynn_Korne"
+			"dynn_Lecca"
+			"dynn_LereS_ti"
+			"dynn_Magheru"
+			"dynn_Marineanu"
+			"dynn_Miclescu"
+			"dynn_MovilA_"
+			"dynn_MA_nA_stireanu"
+			"dynn_Niculescu_DorobanT_u"
+			"dynn_PA_cleanu"
+			"dynn_Pisoschi"
+			"dynn_PleS_ia"
+			"dynn_PleS_nilA_"
+			"dynn_PleS_oianu"
+			"dynn_RacovitzA_"
+			"dynn_RA_S_canu"
+			"dynn_Rallet"
+			"dynn_Rosetti"
+			"dynn_RusA_neS_ti"
+			"dynn_Savoia"
+			"dynn_Stoicescu"
+			"dynn_S_oarec"
+			"dynn_S_oldan"
+			"dynn_TurbureS_ti"
+			"dynn_UrlA_T_eni"
+			"dynn_VidraS_cu"
+			"dynn_Yarka"
 			#not sure what dynasty names Kupala would have
 		}
 
 		dynasty_names = {
+			"dynn_Litovoi"
+			"dynn_SelimoviC_"
+			"dynn_CsA_ky"
+			"dynn_DezsO_fi"
+			"dynn_Guthi-OrszA_gh"
+			"dynn_MarczaltO_vi"
+			"dynn_Petenye"
+			"dynn_Tibai"
+			"dynn_ZA_ch"
+			"dynn_Szapolyai"
+			"dynn_VA_rdai"
+			"dynn_ProdaniC_"
+			"dynn_Odescalchi"
+			"dynn_Costin"
+			"dynn_BA_dA_rA_u"
+			"dynn_BA_lA_ceanu"
+			"dynn_Bosie"
+			"dynn_BrA_iloi"
+			"dynn_BuS_ilA_"
+			"dynn_Calerghi"
+			"dynn_Callimachi"
+			"dynn_Cantemir"
+			"dynn_Carianopol"
+			"dynn_Crihan"
+			"dynn_Carionfil"
+			"dynn_Cristescu"
+			"dynn_Casassovici"
+			"dynn_Cesianu"
+			"dynn_ChinteS_ti"
+			"dynn_Chirescu"
+			"dynn_CoteS_ti"
+			"dynn_CraioveS_tilor"
+			"dynn_CrA_snaru"
+			"dynn_Dinastia"
+			"dynn_DA_neS_tilor"
+			"dynn_Diamandy"
+			"dynn_DrA_culeS_tilor"
+			"dynn_DrugA_"
+			"dynn_Eliescu"
+			"dynn_Emandi"
+			"dynn_Filipescu"
+			"dynn_Florescu"
+			"dynn_FundA_T_eni"
+			"dynn_Giosani"
+			"dynn_Golescu"
+			"dynn_GrA_diS_teanu"
+			"dynn_Greceanu"
+			"dynn_Hagi"
+			"dynn_HA_jdA_u"
+			"dynn_Jianu"
+			"dynn_Korne"
+			"dynn_Lecca"
+			"dynn_LereS_ti"
+			"dynn_Magheru"
+			"dynn_Marineanu"
+			"dynn_Miclescu"
+			"dynn_MovilA_"
+			"dynn_MA_nA_stireanu"
+			"dynn_Niculescu_DorobanT_u"
+			"dynn_PA_cleanu"
+			"dynn_Pisoschi"
+			"dynn_PleS_ia"
+			"dynn_PleS_nilA_"
+			"dynn_PleS_oianu"
+			"dynn_RacovitzA_"
+			"dynn_RA_S_canu"
+			"dynn_Rallet"
+			"dynn_Rosetti"
+			"dynn_RusA_neS_ti"
+			"dynn_Savoia"
+			"dynn_Stoicescu"
+			"dynn_S_oarec"
+			"dynn_S_oldan"
+			"dynn_TurbureS_ti"
+			"dynn_UrlA_T_eni"
+			"dynn_VidraS_cu"
+			"dynn_Yarka"
 
 		}
 
@@ -867,70 +1021,233 @@ brigid_group = {
 
 		color = hsv { 181 199 121 }
 
-		cadet_dynasty_names = {
-			"dynn_Macneary"
-			#maybe just throw in a bunch of Scottish/Irish (idk) names here?
+		cadet_dynasty_names = { #Gaelic + Scottish
+			dynn_Macneary
+			{ "dynnp_a_" "dynn_Phearsain" }
+			{ "dynnp_a" "dynn_Baidenaich" }
+			{ "dynnp_a" "dynn_Cairge" }
+			{ "dynnp_a" "dynn_DU_in_Chaillden" }
+			{ "dynnp_a" "dynn_GabrA_in" }
+			{ "dynnp_a" "dynn_hE_rinn" }
+			{ "dynnp_a" "dynn_hInberuraid" }
+			{ "dynnp_a" "dynn_Lemnain" }
+			{ "dynnp_a" "dynn_Monid-TE_daich" }
+			{ "dynnp_a" "dynn_ScO_ine" }
+			{ "dynnp_a" "dynn_Sratha_Balgaid" }
+			{ "dynnp_an" "dynn_Dorsair" }
+			{ "dynnp_mac" "dynn_Aillein" }
+			{ "dynnp_na" "dynn_Ceardadh" }
+			dynn_A__Mhaoirne
+			dynn_BairE_ad
+			dynn_Breitheamh
+			dynn_Caimbeul
+			dynn_Cataibh
+			dynn_Ceanadach
+			dynn_Ceitein
+			dynn_Cormaig
+			dynn_Donnchaid
+			dynn_Gallaibh
+			dynn_Glaschu
+			dynn_Grannd
+			dynn_Lachlainn
+			{ "dynnp_mac" "dynn_a__Chruiteir" }
+			{ "dynnp_mac" "dynn_a__Phearsain" }
+			{ "dynnp_mac" "dynn_A_egusa" }
+			{ "dynnp_mac" "dynn_Adaim" }
+			{ "dynnp_mac" "dynn_Alaxandair" }
+			{ "dynnp_mac" "dynn_Amhlaigh" }
+			{ "dynnp_mac" "dynn_Amlaigh" }
+			{ "dynnp_mac" "dynn_Arailt" }
+			{ "dynnp_mac" "dynn_Bethain" }
+			{ "dynnp_mac" "dynn_Cainnig" }
+			{ "dynnp_mac" "dynn_CennE_tig" }
+			{ "dynnp_mac" "dynn_Coistela" }
+			{ "dynnp_mac" "dynn_Domnaill" }
+			{ "dynnp_mac" "dynn_Donnchada" }
+			{ "dynnp_mac" "dynn_Dubgaill" }
+			{ "dynnp_mac" "dynn_Dubgaill" }
+			{ "dynnp_mac" "dynn_DubSithe" }
+			{ "dynnp_mac" "dynn_EO_gain" }
+			{ "dynnp_mac" "dynn_EO_in_Duib" }
+			{ "dynnp_mac" "dynn_Fergusa" }
+			{ "dynnp_mac" "dynn_FindlA_ich" }
+			{ "dynnp_mac" "dynn_FinnagA_in" }
+			{ "dynnp_mac" "dynn_Gille-FA_elain" }
+			{ "dynnp_mac" "dynn_Gillebrath" }
+			{ "dynnp_mac" "dynn_Gillepatraig" }
+			{ "dynnp_mac" "dynn_Ilwham" }
+			{ "dynnp_mac" "dynn_in_Baird" }
+			{ "dynnp_mac" "dynn_in_Rothaich" }
+			{ "dynnp_mac" "dynn_in_Toisich" }
+			{ "dynnp_mac" "dynn_in_tSagairt" }
+			{ "dynnp_mac" "dynn_LE_oit" }
+			{ "dynnp_mac" "dynn_NE_ill" }
+			{ "dynnp_mac" "dynn_Ragnaill" }
+			{ "dynnp_mac" "dynn_Ruaidri" }
+			{ "dynnp_mac" "dynn_Torfinn" }
+			{ "dynnp_mac" "dynn_Uchtraigh" }
+			{ "dynnp_mac" "dynn_Uilleim" }
+			dynn_Machair
+			dynn_Madethyn
+			dynn_Muireadhach
+			dynn_Na_Rannaibh
+			dynn_Neacail
+			dynn_SdI_bard
+			dynn_Sgain
+			dynn_Siorrachd
+			dynn_Somhairle
+			dynn_Srath_Nid
 		}
 
 		dynasty_names = {
+			dynn_Macneary
+			{ "dynnp_a_" "dynn_Phearsain" }
+			{ "dynnp_a" "dynn_Baidenaich" }
+			{ "dynnp_a" "dynn_Cairge" }
+			{ "dynnp_a" "dynn_DU_in_Chaillden" }
+			{ "dynnp_a" "dynn_GabrA_in" }
+			{ "dynnp_a" "dynn_hE_rinn" }
+			{ "dynnp_a" "dynn_hInberuraid" }
+			{ "dynnp_a" "dynn_Lemnain" }
+			{ "dynnp_a" "dynn_Monid-TE_daich" }
+			{ "dynnp_a" "dynn_ScO_ine" }
+			{ "dynnp_a" "dynn_Sratha_Balgaid" }
+			{ "dynnp_an" "dynn_Dorsair" }
+			{ "dynnp_mac" "dynn_Aillein" }
+			{ "dynnp_na" "dynn_Ceardadh" }
+			dynn_A__Mhaoirne
+			dynn_BairE_ad
+			dynn_Breitheamh
+			dynn_Caimbeul
+			dynn_Cataibh
+			dynn_Ceanadach
+			dynn_Ceitein
+			dynn_Cormaig
+			dynn_Donnchaid
+			dynn_Gallaibh
+			dynn_Glaschu
+			dynn_Grannd
+			dynn_Lachlainn
+			{ "dynnp_mac" "dynn_a__Chruiteir" }
+			{ "dynnp_mac" "dynn_a__Phearsain" }
+			{ "dynnp_mac" "dynn_A_egusa" }
+			{ "dynnp_mac" "dynn_Adaim" }
+			{ "dynnp_mac" "dynn_Alaxandair" }
+			{ "dynnp_mac" "dynn_Amhlaigh" }
+			{ "dynnp_mac" "dynn_Amlaigh" }
+			{ "dynnp_mac" "dynn_Arailt" }
+			{ "dynnp_mac" "dynn_Bethain" }
+			{ "dynnp_mac" "dynn_Cainnig" }
+			{ "dynnp_mac" "dynn_CennE_tig" }
+			{ "dynnp_mac" "dynn_Coistela" }
+			{ "dynnp_mac" "dynn_Domnaill" }
+			{ "dynnp_mac" "dynn_Donnchada" }
+			{ "dynnp_mac" "dynn_Dubgaill" }
+			{ "dynnp_mac" "dynn_Dubgaill" }
+			{ "dynnp_mac" "dynn_DubSithe" }
+			{ "dynnp_mac" "dynn_EO_gain" }
+			{ "dynnp_mac" "dynn_EO_in_Duib" }
+			{ "dynnp_mac" "dynn_Fergusa" }
+			{ "dynnp_mac" "dynn_FindlA_ich" }
+			{ "dynnp_mac" "dynn_FinnagA_in" }
+			{ "dynnp_mac" "dynn_Gille-FA_elain" }
+			{ "dynnp_mac" "dynn_Gillebrath" }
+			{ "dynnp_mac" "dynn_Gillepatraig" }
+			{ "dynnp_mac" "dynn_Ilwham" }
+			{ "dynnp_mac" "dynn_in_Baird" }
+			{ "dynnp_mac" "dynn_in_Rothaich" }
+			{ "dynnp_mac" "dynn_in_Toisich" }
+			{ "dynnp_mac" "dynn_in_tSagairt" }
+			{ "dynnp_mac" "dynn_LE_oit" }
+			{ "dynnp_mac" "dynn_NE_ill" }
+			{ "dynnp_mac" "dynn_Ragnaill" }
+			{ "dynnp_mac" "dynn_Ruaidri" }
+			{ "dynnp_mac" "dynn_Torfinn" }
+			{ "dynnp_mac" "dynn_Uchtraigh" }
+			{ "dynnp_mac" "dynn_Uilleim" }
+			dynn_Machair
+			dynn_Madethyn
+			dynn_Muireadhach
+			dynn_Na_Rannaibh
+			dynn_Neacail
+			dynn_SdI_bard
+			dynn_Sgain
+			dynn_Siorrachd
+			dynn_Somhairle
+			dynn_Srath_Nid
 
 		}
 
 		male_names ={
-			Aaron_Aaron Abbán Abner_Abner Abél_Abel Adomnán Áed_Hugh Áedgen Áeducán Áedán_Hugh Áengus_Angus Affiath Ailbe Ailbrend Ailbrenn Ailchú Aildobur Ailgel Áilgenán Ailgus
-			Ailill Ailpín_Alwin Ainbchellach Áindle Ainftech_Enfidaig Ainmere Airechtach Airfhindán Airfhinnán Airleid Airmedach Amalgaid Amlaíb_Olaf Anfudán Anlón Anmchaid Ánrothán Ardgal
-			Ardgar Art_Arthur Artbran Artgal Artgus Artucán Artúr_Arthur Assiucc Augaire Augustín_Augustine Aurthuile Báethgalach Báethíne Báetán Béoáed Barrfhind Beccán Berrach Bhátair_Walter
-			Blathmacc Bran_Bran Brandub Brangen Bressal Brian_Brian Briccéne Briccíne Broccán Bruatur Bruide_Bride Brénaind Brénainn Bróen Búaidbéo Caicher Cailech Cailte Cairbre_Carbrey
-			Cairell Caisséne Caissín Caissíne Canann Canannán Carlus_Charles Cathal Cathalán Cathassach Cathbad Cathmáel Cathmál Cathnio Cathub Causantín_Constantine Caílte Caínchomrac
-			Caíndelbán Ceithernach Cellach Cellachán Cennétig_Kentigern Cenn-Fáelad Cennlachán Cerball Cernach Cernachán Cian Ciarán Cilléne Cillíne Cináed_Kenneth Clemens_Clement Cobthach
-			Coirpre Colcu Colmán_Nicholas Columb_Nicholas Comgán Conaing Conall_Conall Conallán Conamail Conán_Conan Conchenn Conchobar Condla Congal Congalach Congus Conlang Conmac Conmacc
-			Conmáel Conmál Conn_Conn Connla Conrí Constans_Constantius Constantín_Constantine Corbb Corbán Corccán Corcrán Cormac Coscrach Coílboth Crimthann Crundmáel_Crundmáel Cruinnmáel_Crundmáel
-			Críchán Crónán Cuilén Cuindles Cuircthe Cummascach Cáemán Cóelbad Cóelub Cóemán Cú-Allaid Cú-Bretan Cú-Caech Cú-Cen Cú-Cen-Máthair Cú-Cúaráin Cú-Gamna Cú-Roí Cúanu Cúldub Cúán
-			Cúánán Dabíd_David Daigre Dalbach Dallán Daniél_Daniel Dathal Dathgus Demmán Diarmait_Dermid Doedgus Domangart Domnall_Donald Donn Donnchad_Duncan Donncuan_Duncan Donndubán Donngal
-			Donnucán_Duncan Doélgus Drost Drust Dub-dá-Lethe Dubcenn Dubgenn Dubh_Duff Dubhghall_Dugald Dubhglais_Douglas Dubthach Dubáed Dubán Duiblesc Duibne Dunáed Dálach Dícuill Díglach Dímmae
-			Dímmasach Dímmán Dínertach Dúnacán Dúnadach Dúnchad_Duncan Dúngal Dúngalach Dúnlang Éamonn_Edmund Echmarcach Échtgal Échtgus Echthigern Echuid Éicnech Éicnechán Eláir Énna Énri_Henry Éochad
-			Eochaid_Eochaid Eochu Eochucán Éogan_Eugene Erc_Eric Ercaid Ercáed Ercán Éremón Érennach Ernán Eterscél Eógan_Eugene Eóganán_Eugene Fachtna Fairchellach Fallaman Farannán Faílbe Fearghus_Fergus
-			Fechtnach Fedach Fearchar_Farquhar Fedelmid Feirgil Felic Fer-Fugaill Feradach_Feradach Ferdomnach Fergal Fergus_Fergus Fiachnae Fianchú Findbarr Fingen Finguine Finn_Finn Finnacán Finnbarr
-			Finnchú Finnlagh_Findlay Finnsnechtae Fintan Flaithbertach Flaithem Flaithemán Flaithgus Flaithrí Flann Flannacán Flannchad Flannán Fogartach Folachtach Forannán Forbassach Fothad Fothud
-			Fuacarta Fubthad Fuirechtach Fursu Fáelcar Fáelchad Fáelchú Fáeldobur Fáelgus Fáelán Fáelbe Fíachnae Fíadchú Fíngin Fínsnechta Fócarta Gabrán Garalt Garbith Gilla-Íosa Gilla-Brígte_Gilbert
-			Gilla-Coluim Gilla-Comgáin Gilla-Críst_Gilchrist Gilla-na-Náem Gilla-Pátraic_Gilpatrick Gilla-Ruad_Gilroy Glaisiuc Glaschu Glún-Iairn Gofraid_Godfrey Gormacán Gormgus Gormán Guaire Gáethán
-			Gáethíne Gósacht Iacob_Jacob Iarlaithe Imchad Indrechtach Ioseph_Joseph Íomhar_Ivar Labraid Lachtnae Lachtnán Lachtnéne Laidcenn Laidgenn Laidíne Laisrén Lennán_Lennon Lethlobur Liam_William
-			Liber Lochlann Loingsech Lonán Lorcán Lugh_Leon Lugaid Lugáed Láegaire Lóchéne Lóchíne Lóeguire Mac-Laisre Mainchíne Maine Manchán Martan Mathgamain Matudán Minchán Mo-Chonna Mo-Lua Móenach
-			Morand Morann Mugrón Muirchertach Muirecán Muiredach_Murdoch Muirgius Murchad Murchú Máel-Anfaid Máel-Bresail Máel-Brígte Máel-Cein Máel-Cianáin Máel-Ciaráin Máel-Coluim_Malcolm Máel-Corgis
-			Máel-Dubh_Maldoven Máel-Dúin Máel-Fothartaig Máel-Fábaill Máel-Íosa_Malise Máel-Máedóc Máel-Martain Máel-Mórda Máel-Muire_Malmure Máel-Míchíl Máel-Petair Máel-Pátraic Máel-Ruanaid Máel-Sechnaill
-			Máel-Tólai Máelán Máenach Máthair Múadán Nadarchu Nannid Natfraech Natfraich Natsluaig Nechtan_Nathan Niall_Nigel Niallgus Niallán Nuadu Odrán Óengus_Angus Óenucán Oisséne Oissíne Olcán Ólchobar
-			Onchú Orthanach Oscar_Oscar Pátraic_Patrick Petair_Peter Pilib_Philip Pól_Paul Proinsias_Francis Rechtabra Riacán Riaguil Robartach Rogallach Rogellach Ruah_Roy Ruaidrí_Roderick Ruarcc Rumann
-			Ráthach Rígán Ríán Ródán Rónchú Rónán_Ronan Rúadacán Rúadán Scandal Scandlán Scellán Scolaige Séaghdha_Shaw Séafra_Godfrey Séamas_Jacob Seán_John Sechnassach Selbach Senchán Seoán_John Sinach
-			Siothrún_Godfrey Slébíne Snedgus Sogan Somhairle_Somerled Suibne_Sweeny Sáerbrethach Sárán Séigíne Sétna Sétnae Tadg_Tadg Taithlech Talorc_Talore Talorcán_Talorcán Temnén Tigernach Tigernán
-			Tipraite Tomaltach Tomás_Thomas Torccán Trenchad Trengus Tressach Tuathalán Tuireann_Taran Tálán Tóla Túathal_Tuathal Ualgarg Ualan_Valentin Ualtar_Walter Úamnachán Uargal Uargalach Uargus
-			Uilliam_William Ultán
+			Aaron AbbA_n Abner AbE_l AdomnA_n A_ed A_edgen A_educA_n A_edA_n A_engus Affiath Ailbe Ailbrend Ailbrenn AilchU_ Aildobur Ailgel A_ilgenA_n Ailgus
+			Ailill AilpI_n Ainbchellach A_indle Ainftech Ainmere Airechtach AirfhindA_n AirfhinnA_n Airleid Airmedach Amalgaid AmlaI_b AnfudA_n AnlO_n Anmchaid A_nrothA_n Ardgal
+			Ardgar Art Artbran Artgal Artgus ArtucA_n ArtU_r Assiucc Augaire AugustI_n Aurthuile BA_ethgalach BA_ethI_ne BA_etA_n BE_oA_ed Barrfhind BeccA_n Berrach BhA_tair
+			Blathmacc Bran Brandub Brangen Bressal Brian BriccE_ne BriccI_ne BroccA_n Bruatur Bruide BrE_naind BrE_nainn BrO_en BU_aidbE_o Caicher Cailech Cailte Cairbre
+			Cairell CaissE_ne CaissI_n CaissI_ne Canann CanannA_n Carlus Cathal CathalA_n Cathassach Cathbad CathmA_el CathmA_l Cathnio Cathub CausantI_n CaI_lte CaI_nchomrac
+			CaI_ndelbA_n Ceithernach Cellach CellachA_n CennE_tig Cenn-FA_elad CennlachA_n Cerball Cernach CernachA_n Cian CiarA_n CillE_ne CillI_ne CinA_ed Clemens Cobthach
+			Coirpre Colcu ColmA_n Columb ComgA_n Conaing Conall ConallA_n Conamail ConA_n Conchenn Conchobar Condla Congal Congalach Congus Conlang Conmac Conmacc Cailean
+			ConmA_el ConmA_l Conn Connla ConrI_ Constans ConstantI_n Corbb CorbA_n CorccA_n CorcrA_n Cormac Coscrach CoI_lboth Crimthann CrI_nA_n CrundmA_el CruinnmA_el
+			CrI_chA_n CrO_nA_n CuilE_n Cuindles Cuircthe Cummascach CA_emA_n CO_elbad CO_elub CO_emA_n CU_-Allaid CU_-Bretan CU_-Caech CU_-Cen CU_-Cen-MA_thair CU_-CU_arA_in CU_-Gamna CU_-RoI_ CU_anu CU_ldub CU_A_n
+			CU_A_nA_n DabI_d Daigre Dalbach DallA_n DaniE_l Dathal Dathgus DemmA_n Drystan Diarmait Doedgus Domangart Domnall Donn Donnchad Donncuan DonndubA_n Donngal
+			DonnucA_n DoE_lgus Drost Drust Dub-dA_-Lethe Dubcenn Dubgenn Dubh Dubhghall Dubhglais Dubthach DubA_ed DubA_n Duib Duiblesc Duibne DunA_ed DA_lach DI_cuill DI_glach DI_mmae
+			DI_mmasach DI_mmA_n DI_nertach DU_nacA_n DU_nadach DU_nchad DU_ngal DU_ngalach DU_nlang E_amonn Echmarcach E_chtgal E_chtgus Echthigern Echuid E_icnech E_icnechA_n ElA_ir E_nna E_nri E_ochad
+			Eochaid Eochu EochucA_n E_ogan Erc Ercaid ErcA_ed ErcA_n E_remO_n E_rennach ErnA_n EterscE_l EO_gan EO_ganA_n Fachtna Fairchellach Fallaman FarannA_n FaI_lbe Fearghus
+			Fechtnach Fedach Fearchar Fedelmid Feirgil Felic Fer-Fugaill Feradach Ferdomnach Fergal Fergus Fiachnae FianchU_ Findbarr Fingen Finguine Finn FinnacA_n Finnbarr
+			FinnchU_ Finnlagh Finnsnechtae Fintan Flaithbertach Flaithem FlaithemA_n Flaithgus FlaithrI_ Flann FlannacA_n Flannchad FlannA_n Fogartach Folachtach ForannA_n Forbassach Fothad Fothud
+			Fuacarta Fubthad Fuirechtach Fursu FA_elcar FA_elchad FA_elchU_ FA_eldobur FA_elgus FA_elA_n FA_elbe FI_achnae FI_adchU_ FI_ngin FI_nsnechta FO_carta GabrA_n Garalt Garbith Gilla-I_osa Gilla-BrI_gte
+			Gilla-Coluim Gilla-ComgA_in Gilla-CrI_st Gilla-na-NA_em Gilla-PA_traic Gilla-Ruad Glaisiuc Glaschu GlU_n-Iairn Gofraid GormacA_n Gormgus GormA_n Guaire GA_ethA_n
+			GA_ethI_ne GO_sacht Iacob Iarlaithe Ildulb Imchad Indrechtach Ioseph I_omhar Labraid Lachtnae LachtnA_n LachtnE_ne Laidcenn Laidgenn LaidI_ne LaisrE_n LennA_n Lethlobur Liam
+			Liber Lochlann Loingsech LonA_n LorcA_n Lugh Lugaid LugA_ed LA_egaire LO_chE_ne LO_chI_ne LO_eguire Macbethad Muirgein MA_elSnechtai Mac-Laisre MainchI_ne Maine ManchA_n Martan Murethach Mathgamain MatudA_n MinchA_n Mo-Chonna Mo-Lua MO_enach
+			Morand Morann MugrO_n Muirchertach MuirecA_n Muiredach Muirgius Murchad MurchU_ MA_el-Anfaid MA_el-Bresail MA_el-BrI_gte MA_el-Cein MA_el-CianA_in MA_el-CiarA_in MA_el-Coluim MA_el-Corgis
+			MA_el-Dubh MA_el-DU_in MA_el-Fothartaig MA_el-FA_baill MA_el-I_osa MA_el-MA_edO_c MA_el-Martain MA_el-MO_rda MA_el-Muire MA_el-MI_chI_l MA_el-Petair MA_el-PA_traic MA_el-Ruanaid MA_el-Sechnaill
+			MA_el-TO_lai MA_elA_n MA_enach MA_thair MU_adA_n Nadarchu Nannid Natfraech Natfraich Natsluaig Nechtan Niall Niallgus NiallA_n Nuadu OdrA_n O_engus O_enucA_n OissE_ne OissI_ne OlcA_n O_lchobar
+			OnchU_ Orthanach Oscar PA_traic Petair Pilib PO_l Proinsias Rechtabra RiacA_n Riaguil Robartach Rogallach Rogellach Ruah RuaidrI_ Ruarcc Rumann
+			RA_thach RI_gA_n RI_A_n RO_dA_n RO_nchU_ RO_nA_n RU_adacA_n RU_adA_n Scandal ScandlA_n ScellA_n Scolaige SE_aghdha SE_afra SE_amas SeA_n Sechnassach Selbach SenchA_n SeoA_n Sinach
+			SiothrU_n SlE_bI_ne Snedgus Sogan Somhairle Suibne SA_erbrethach SA_rA_n SE_igI_ne SE_tna SE_tnae Tadhg Taithlech Talorc TalorcA_n TemnE_n Tigernach TigernA_n
+			Tipraite Tomaltach TomA_s TorccA_n Trenchad Trengus Tressach TuathalA_n Tuireann TA_lA_n TO_la TU_athal Ualgarg Ualan Ualtar U_amnachA_n Uargal Uargalach Uargus
+			Adam Alpin Alan Alastair Alexander Andrew
+			Angus Archibald Arthur Arran Aulay Beathan Brian Brice Cailean Calum Carbrey Colban
+			Colin Conall Conan Constantine David Dermid Donald Douglas Duff Dugald
+			Duncan Edgar Edward Edwin Eric Evander Ewan Farquhar Fergus Fingal Findlay Frang
+			Gavin Gilbert Gilbride Gilchrist Gillespie Gilpatrick Gilroy Giric Glenn Godfrey Gregor
+			Hamish Hector Henry Hugh Iain Indulf James John Kenneth Kentigern Lachlan Laurence Lennon
+			Lulach Macbeth Magnus Malcolm Maldoven Maldred Malise Malmure Maoilios Marcas Malsnectan
+			Matad Matthew Michael Morgan Muir Mungo Murdoch Murray Neil Ninian Oscar
+			Patrick Paul Peter Philip Radulf Ranald Richard Robert Roderick Ronald Rory Ross Roy
+			Shaw Sholto Simon Somerled Stephan Sweeny Taig Talore Thomas Torquil Uhtred Uisdean Walan
+			Waldeve Walter William
 		}
 
 		female_names = {
-			Ablach Áedammair Affraic_Euphemia Aíbinn Aibilín_Eva Aileann Áine_Agnes Anlaith Aróc 
-			Barrdub Ben-Laigen Ben-Míde Ben-Muman Ben-Ulad Brigit_Brigit  Bé-Fáil Bébinn 
-			Cacht Caillech-Fhinnéin
-			Cainnech Caisséne Caitilín_Catherine Caíntigern Caírech Cathán Catríona_Catherine Cellach Ciar Cnes Coblaith_Cobflaith Cobflaith_Cobflaith Conchenn Condál Crínóch Crístina_Christina Cumman
-			Deirdre Der-bForgaill_Devorguilla Derbáil Derborgaill_Devorguilla Der-Ilei_Derilla Der-Lugdach Dianaim Doriend Dub-Dil Dub-Essa Dub-Lemna Dubchoblaig Dubgilla Dúinsech Dúnlaith 
-			Echrad Éibhleann Eilionora_Eleanor Eithne_Eithne Ellbríg Emer_Emer Étaín Éua_Eva Euginia_Eugenia 
-			Faílenn Fedelm Finneacht Finnguala_Finnguala Flann Forbflaith Fíne 
-			Garb Gelgéis Gerróc Gnathnad Gormflaith_Gormflaith Gormlaith_Gormflaith Gráinne 
-			Imag Íte 
-			Lann Lasairfíona Lathir Lerben Lerthan Lígach Lucia_Lucia 
-			Martha_Martha Mauda_Matilda Muadhnait_Mona Muirenn_Murron Muirgel_Muriel Muirne_Morna Máel-Mide Máel-Muire_Malmure Máire_Maria Máiread Máirgred_Margaret Mór_Mor Mór-Muman 
-			Nárbflaith Nuala_Finnguala 
-			Órlaith Órnat
+			Ablach A_edammair Affraic AI_binn AibilI_n Aileann A_ine Anlaith Anleta ArO_c 
+			Barrdub Ben-Laigen Ben-MI_de Ben-Muman Ben-Ulad Brigit  BE_-FA_il BE_binn 
+			Cacht Caillech-FhinnE_in Cainnech CaissE_ne CaitilI_n CaI_ntigern CaI_rech CathA_n CatrI_ona Cellach Ciar Cnes Coblaith Cobflaith Conchenn CondA_l CrI_nO_ch CrI_stina Cumman
+			Deirdre Der-bForgaill DerbA_il Derborgaill Der-Ilei Der-Lugdach Dianaim Doriend Dub-Dil Dub-Essa Dub-Lemna Dubchoblaig Dubgilla DU_insech DU_nlaith 
+			Echrad E_ibhleann Eilionora Eithne EllbrI_g Emer E_taI_n E_ua Euginia 
+			FaI_lenn Fedelm Finneacht Finnguala Flann Forbflaith FI_ne 
+			Garb Gormuil GelgE_is GerrO_c Gnathnad Gormflaith Gormlaith GrA_inne 
+			Imag I_te 
+			Lann LasairfI_ona Lathir Lerben Lerthan LI_gach Lucia 
+			Martha Mauda Muadhnait Muirenn Muirgel Muirne MA_el-Mide MA_el-Muire MA_ire MA_iread MA_irgred MO_r MO_r-Muman 
+			NA_rbflaith Nuala 
+			O_rlaith O_rnat 
 			Petra
-			Róis_Ros 
-			Sadb Samthann Scáthach Sébdann Selblaith Seonaid_Joan Sinech Siobán_Joan
-			Sisuile Sláíne_Slaine Sorcha_Sorcha Suaibsech Sáerlaith Sétach Síthmaith 
-			Tailefhlaith Tailltiu Temair Tuathflaith Tómnat 
-			Uallach Uasal Úna_Una
+			RO_is 
+			Sadb Samthann ScA_thach SE_bdann Selblaith Seonaid Sinech SiobA_n Sisuile SlA_I_ne Sorcha Suaibsech SA_erlaith SE_tach SI_thmaith 
+			Tailefhlaith Tailltiu Temair Tuathflaith TO_mnat 
+			Uallach Uasal U_na
+			Ada Affraic Agnes Aileen Alice Anna Annabella Aufrica Barabal Beileag Beitris Beathoc Bride
+			Catriona Cecilia Christina Deirdre Derilla Dervorgilla Donada Donella
+			Edith Edna Effie Eilionoir Eimhir Eithne Ela Eleanor Elspeth Euna Eva Fenella Fingola Flora
+			Forflissa Galiena Glenna Gormelia Gruoch Helen Innes Iona Isabel Isla Isobel Jean Julia
+			Kenna Kentigerna Kirstin Lillias Lorna Malmure Maisie Malina Margaret Mariota Marjory Mary
+			Martha Marthoc Maud Maura Mirren Mor Morag Morna Moyna Muriel
+			Murron Nuala Orabilia Peigi Rhonda Rodina Ronalda Ros Saundra Sheena Shona Slaine Sorcha Steacy Una
 		}
 
-		patronym_prefix_male = "dynnpat_pre_nic"
-		patronym_prefix_female = "dynnpat_pre_nic"
-		dynasty_of_location_prefix = "dynnp_de"
+		patronym_prefix_male = "dynnpat_pre_Mac" #more in line with vanilla CK3 patronym
+		patronym_prefix_female = "dynnpat_pre_Mac" #Petra is a girl and uses "Mac", but it could just be a dynasty name
+		dynasty_of_location_prefix = "dynnp_a"
 		prefix = yes
 		
 		always_use_patronym = yes	#Petra doesn't use a patronym so maybe these should be removed later
@@ -955,6 +1272,14 @@ brigid_group = {
 		mercenary_names = {
 			{ name = "mercenary_company_lawgochs_followers" }
 			{ name = "mercenary_company_band_of_horned_welshmen" }
+			{ name = mercenary_company_border_reivers }
+			{ name = mercenary_company_warband_of_the_great_hall }
+			{ name = mercenary_company_company_of_the_kings_son }
+			{ name = mercenary_company_gallowglasses }
+			{ name = mercenary_company_redshanks }
+			{ name = mercenary_company_band_of_kerns }
+			{ name = mercenary_company_madhmanns_company }
+			{ name = mercenary_company_company_of_shield_and_scian }
 		}
 	}
 }
@@ -967,13 +1292,43 @@ outside_group = {
 
 		color = hsv { 181 147 119 }
 
-		cadet_dynasty_names = {
+		cadet_dynasty_names = {	#Sardinian names, not too Italian
 			"dynn_Molinaro"
+			"dynn_Floris"
+			"dynn_Gambella"
+			"dynn_Manca"
+			"dynn_Melis"
+			"dynn_Meloni"
+			"dynn_Mura"
+			"dynn_Pinna"
+			"dynn_Piras"
+			"dynn_Porcu"
+			"dynn_Salusiu_de_Lacon"
+			"dynn_Sanna"
+			"dynn_Serra"
+			"dynn_Spanu"
+			"dynn_Torchitorio"
+			"dynn_Usai"
 			#Molinaro is Italian but Leicester uses Italian names too (Pinelli) so idk what else to have here
 		}
 
 		dynasty_names = {
 			"dynn_Molinaro"
+			"dynn_Floris"
+			"dynn_Gambella"
+			"dynn_Manca"
+			"dynn_Melis"
+			"dynn_Meloni"
+			"dynn_Mura"
+			"dynn_Pinna"
+			"dynn_Piras"
+			"dynn_Porcu"
+			"dynn_Salusiu_de_Lacon"
+			"dynn_Sanna"
+			"dynn_Serra"
+			"dynn_Spanu"
+			"dynn_Torchitorio"
+			"dynn_Usai"
 		}
 
 		male_names ={
@@ -994,6 +1349,12 @@ outside_group = {
 			Unsue
 			Wadja Wahib Weneg
 			Zamon
+			Amyrteo Ankhmacho Anemhor Arats Argano Charia Djedhor Ezena Horemakhet Isocrate Khabbabash Leonippe Lydiada Manetho Massiva
+ 			Nakhthoreb Narava Nefaarud Neferibre Nesisti Nicia Nicodemuo Oezalce Oxynta Pedubasto Peneo Perdicca Filocrate 
+			Filoteo Polypercho Psherenamun Psherenptah Psammuthe Ptolemeo Teocrito Terapo Timoleo Xantho Xeno Zetere Zosimus Ahmes
+			Ahmose Alaro Amaso Ameny Bakenrenef Cleomene Euclid Harsiotef Henut Ibi Khabash Lago Nectanebo Kheperkare Neferkare Nehi Osorkon Pami
+			Petubastis Teos
+			#Italianized forms of Nubian and Egyptian names from Imperator
 		}
 
 		female_names = {
@@ -1007,6 +1368,9 @@ outside_group = {
 			Raya Rekhe
 			Siri Setha Satia Seshe Sita Sobhe
 			Tawa Tabi Tey Tia Tiye
+			Agape Agathoclea Amanishabheto Antigone Apame Apollonia Aristomache Artemisia Aspassia Athenais Berenice Charis Cleopatra Cynna
+			Demetria Elpis Irene Eudossia Eunisse Eufemia Eurydisse Eutalia Hypatia Nysa Oenante Olympia Phila Phile Sostrate Stratonisse Thais
+			Teofila Thetima Tessalonike Torake Timo Arsinoe Lysandra Kiya Qelhata
 		}
 
 		dynasty_of_location_prefix = "dynnp_di"
@@ -1043,12 +1407,174 @@ outside_group = {
 
 		color = hsv { 190 215 25 }
 
-		cadet_dynasty_names = {
-			#TBD
+		cadet_dynasty_names = {	#vanilla Persian dynasties
+			"dynn_Nasrid"
+			"dynn_Mihrabanid"
+			"dynn_Safavid"
+			"dynn_Gilani"
+			"dynn_Sarbadar"
+			"dynn_Kazeruni"
+			"dynn_Tahirids"
+			"dynn_Ummayyads"
+			"dynn_Samanid"
+			"dynn_Muqannid"
+			"dynn_Sunpadh"
+			"dynn_Khurramites"
+			"dynn_Khorramdin"
+			"dynn_Maziar"
+			"dynn_Mardavij"
+			"dynn_Ustadh"
+			"dynn_Saffari"
+			"dynn_Laith"
+			"dynn_Ferdowsi"
+			"dynn_Tamerlane"
+			"dynn_Hulagu"
+			"dynn_Ajami"
+			"dynn_Rumi"
+			"dynn_Hamadan"
+			"dynn_Parthi"
+			"dynn_Kubra"
+			"dynn_Naqshband"
+			"dynn_Bukhari"
+			"dynn_Hanifa"
+			"dynn_Khaldun"
+			"dynn_Dinid"
+			"dynn_Tusid"
+			"dynn_Khusrawid"
+			"dynn_Birunid"
+			"dynn_Maraghid"
+			"dynn_Muqaffid"
+			"dynn_Ashkan"
+			"dynn_KhurA_sA_nI_"
+			"dynn_MA_zindarA_nI_"
+			"dynn_TihrA_nI_"
+			"dynn_ShI_rA_zI_"
+			"dynn_AhvazI_"
+			"dynn_RazavI_"
+			"dynn_MA_shadI_"
+			"dynn_KermahadI_"
+			"dynn_Gaznin"
+			"dynn_Ka_usiya"
+			{ "dynnp_al-" "dynn_Ghazali" }
+			{ "dynnp_al-" "dynn_Qazwini" }
+			{ "dynnp_al-" "dynn_Juwayni" }
+			{ "dynnp_al-" "dynn_Farisi" }
+			"dynn_Hamadani"
+			"dynn_Ganjavi"
+			{ "dynnp_al-" "dynn_Amuli" }
+			"dynn_Balkhi"
+			"dynn_Bukhari"
+			"dynn_Suhrawardi"
+			{ "dynnp_al-" "dynn_Abhari" }
+			{ "dynnp_al-" "dynn_Tusi" }
+			"dynn_Hamadani"
+			{ "dynnp_al-" "dynn_Shirazi" }
+			"dynn_Gorgani"
+			"dynn_Mustawfi"
+			"dynn_Ansari"
+			{ "dynnp_al-" "dynn_Kashi" }
+			"dynn_Kubra"
+			"dynn_KhayyA_m"
+			{ "dynnp_al-" "dynn_Razi" }
+			"dynn_Sina"
+			{ "dynnp_al-" "dynn_Jaldaki" }
+			"dynn_Ishaqid"
+			"dynn_Shi"
+			"dynn_Al-Dawla"
+			"dynn_Yalavach"
+			"dynn_Wardanrid"
+			"dynn_Kakuyid"
+			"dynn_Sughnan"
+			"dynn_Mirs"
+			"dynn_Roshan"
+			"dynn_Gorno"
+			"dynn_Guliab"
+			"dynn_Zulcarnei"
 		}
 
 		dynasty_names = {
-			#TBD
+			"dynn_Nasrid"
+			"dynn_Mihrabanid"
+			"dynn_Safavid"
+			"dynn_Gilani"
+			"dynn_Sarbadar"
+			"dynn_Kazeruni"
+			"dynn_Tahirids"
+			"dynn_Ummayyads"
+			"dynn_Samanid"
+			"dynn_Muqannid"
+			"dynn_Sunpadh"
+			"dynn_Khurramites"
+			"dynn_Khorramdin"
+			"dynn_Maziar"
+			"dynn_Mardavij"
+			"dynn_Ustadh"
+			"dynn_Saffari"
+			"dynn_Laith"
+			"dynn_Ferdowsi"
+			"dynn_Tamerlane"
+			"dynn_Hulagu"
+			"dynn_Ajami"
+			"dynn_Rumi"
+			"dynn_Hamadan"
+			"dynn_Parthi"
+			"dynn_Kubra"
+			"dynn_Naqshband"
+			"dynn_Bukhari"
+			"dynn_Hanifa"
+			"dynn_Khaldun"
+			"dynn_Dinid"
+			"dynn_Tusid"
+			"dynn_Khusrawid"
+			"dynn_Birunid"
+			"dynn_Maraghid"
+			"dynn_Muqaffid"
+			"dynn_Ashkan"
+			"dynn_KhurA_sA_nI_"
+			"dynn_MA_zindarA_nI_"
+			"dynn_TihrA_nI_"
+			"dynn_ShI_rA_zI_"
+			"dynn_AhvazI_"
+			"dynn_RazavI_"
+			"dynn_MA_shadI_"
+			"dynn_KermahadI_"
+			"dynn_Gaznin"
+			"dynn_Ka_usiya"
+			{ "dynnp_al-" "dynn_Ghazali" }
+			{ "dynnp_al-" "dynn_Qazwini" }
+			{ "dynnp_al-" "dynn_Juwayni" }
+			{ "dynnp_al-" "dynn_Farisi" }
+			"dynn_Hamadani"
+			"dynn_Ganjavi"
+			{ "dynnp_al-" "dynn_Amuli" }
+			"dynn_Balkhi"
+			"dynn_Bukhari"
+			"dynn_Suhrawardi"
+			{ "dynnp_al-" "dynn_Abhari" }
+			{ "dynnp_al-" "dynn_Tusi" }
+			"dynn_Hamadani"
+			{ "dynnp_al-" "dynn_Shirazi" }
+			"dynn_Gorgani"
+			"dynn_Mustawfi"
+			"dynn_Ansari"
+			{ "dynnp_al-" "dynn_Kashi" }
+			"dynn_Kubra"
+			"dynn_KhayyA_m"
+			{ "dynnp_al-" "dynn_Razi" }
+			"dynn_Sina"
+			{ "dynnp_al-" "dynn_Jaldaki" }
+			"dynn_Ishaqid"
+			"dynn_Shi"
+			"dynn_Al-Dawla"
+			"dynn_Yalavach"
+			"dynn_Wardanrid"
+			"dynn_Kakuyid"
+			"dynn_Sughnan"
+			"dynn_Mirs"
+			"dynn_Roshan"
+			"dynn_Gorno"
+			"dynn_Guliab"
+			"dynn_Zulcarnei"
 		}
 
 		male_names ={
@@ -1100,12 +1626,24 @@ outside_group = {
 
 		color = hsv { 190 40 155 }
 
-		cadet_dynasty_names = {
-			#TBD
+		cadet_dynasty_names = {	#vanilla Assyrian dynasties
+			"dynn_Bukhtishu"
+			"dynn_Qatwa"
+			"dynn_Nimreh"
+			"dynn_Gazarta"
+			"dynn_Salamas"
+			"dynn_Zakho"
+			"dynn_Arbilaya"
 		}
 
 		dynasty_names = {
-			#TBD
+			"dynn_Bukhtishu"
+			"dynn_Qatwa"
+			"dynn_Nimreh"
+			"dynn_Gazarta"
+			"dynn_Salamas"
+			"dynn_Zakho"
+			"dynn_Arbilaya"
 		}
 
 		male_names ={
@@ -1176,12 +1714,50 @@ outside_group = {
 
 		color = hsv { 190 40 155 }
 
-		cadet_dynasty_names = {
-			#TBD
+		cadet_dynasty_names = { #Tocharian, Norse dynasties sound too Adrestian
+			"dynn_Kausal"
+			"dynn_Gank"
+			"dynn_Tenare"
+			"dynn_Ytarim"
+			"dynn_Tripuskar"
+			"dynn_Dantapur"
+			"dynn_Baransi"
+			"dynn_Yurpaska"
+			"dynn_Rohini"
+			"dynn_Vaideh"
+			"dynn_Vaisali"
+			"dynn_Iksvaku"
+			"dynn_Kausika"
+			"dynn_Kausika"
+			"dynn_Sakke"
+			"dynn_Kasake"
+			"dynn_Yarkam"
+			"dynn_Cadota"
+			"dynn_Lyam"
+			"dynn_Kunlyu"
 		}
 
 		dynasty_names = {
-			#TBD
+			"dynn_Kausal"
+			"dynn_Gank"
+			"dynn_Tenare"
+			"dynn_Ytarim"
+			"dynn_Tripuskar"
+			"dynn_Dantapur"
+			"dynn_Baransi"
+			"dynn_Yurpaska"
+			"dynn_Rohini"
+			"dynn_Vaideh"
+			"dynn_Vaisali"
+			"dynn_Iksvaku"
+			"dynn_Kausika"
+			"dynn_Kausika"
+			"dynn_Sakke"
+			"dynn_Kasake"
+			"dynn_Yarkam"
+			"dynn_Cadota"
+			"dynn_Lyam"
+			"dynn_Kunlyu"
 		}
 
 		male_names ={


### PR DESCRIPTION
Updated Brigid namelist to reflect new naming scheme (i.e. "Áed_Hugh" no longer necessary since name equivalency is defined in the 00_names.txt file under culture_names) and added additional names and/or dynasties for the non Fódan cultures (Italianized Egyptian for Duscur, Persian for Almyran, Assyrian for Morfis, Romanian for Kupala, and Tocharian for Sreng.